### PR TITLE
Disable documentation.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,6 @@ SUBDIRS = \
 	src \
 	data \
 	etc \
-	docs \
 	m4macros \
 	tests \
 	scripts

--- a/configure.ac
+++ b/configure.ac
@@ -177,10 +177,6 @@ AC_SUBST(ADDITIONAL_OBJECTS)
 AC_PATH_PROG(XSLTPROC, xsltproc, no)
 AM_CONDITIONAL(HAVE_XSLTPROC, test "x$XSLTPROC" != "xno")
 
-# Check for asciidoc
-AC_PATH_PROG(A2X, a2x, no)
-AM_CONDITIONAL(HAVE_A2X, test "x$A2X" != "xno")
-
 # checking xmllint
 AC_PATH_PROG(XMLLINT, xmllint, no)
 if test "x$XMLLINT" != "xno"; then
@@ -202,11 +198,6 @@ src/Makefile
 data/Makefile
 data/templates/Makefile
 etc/Makefile
-docs/Makefile
-docs/man5/Makefile
-docs/man5/tinyproxy.conf.txt
-docs/man8/Makefile
-docs/man8/tinyproxy.txt
 m4macros/Makefile
 tests/Makefile
 tests/scripts/Makefile


### PR DESCRIPTION
We have downstream patches for tinyproxy both in Git and in the
recipe, let's simplify by having all of them in Git.

Patch ported over from: http://cgit.openembedded.org/meta-openembedded/

[SPEC-1885] Reorganization and cleanup of Yocto recipes and layers
https://jira.automotivelinux.org/browse/SPEC-1885